### PR TITLE
Update spice_orbit.py

### DIFF
--- a/examples/spice_orbit.py
+++ b/examples/spice_orbit.py
@@ -18,7 +18,7 @@ import numpy as np
 ###############################################################################
 # Load the solar orbiter spice kernel. HelioPy will automatically fetch the
 # latest kernel
-orbiter_kernel = spicedata.get_kernel('solar orbiter 2020')
+orbiter_kernel = spicedata.get_kernel('solo_2020')
 spice.furnish(orbiter_kernel)
 orbiter = spice.Trajectory('Solar Orbiter')
 


### PR DESCRIPTION
ValueError: Provided name solar orbiter 2020 not in list of available names: dict_keys(['lsk', 'planet_trajectories', 'planet_orientations', 'solo_2020', 'helios1', 'helios2', 'juno_rec', 'juno_pred', 'ulysses'])